### PR TITLE
update Ditto to v4.5

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "f43ae6396697a158bce281811ff786b2e7af607e",
-        "version" : "4.4.2"
+        "revision" : "b7ff3bb584798818f56d1488a9176801cfbe6ce9",
+        "version" : "4.5.4"
       }
     },
     {


### PR DESCRIPTION
Update to v4.5, then will push update to app store. This will be a transition period for users to update to v4.5 so when we publish the DQL version it will reduce the risk of breaking.