### PR TITLE
DQL fixes

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -597,7 +597,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 4.4.0;
 			};
 		};
 		14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {
@@ -605,7 +605,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 4.5.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "be03dc47d1517fb669f173833625262340b4aab8",
-        "version" : "4.5.1"
+        "revision" : "b7ff3bb584798818f56d1488a9176801cfbe6ce9",
+        "version" : "4.5.4"
       }
     },
     {

--- a/iOS/DittoPOS/POS/POS_VM.swift
+++ b/iOS/DittoPOS/POS/POS_VM.swift
@@ -11,35 +11,29 @@ import DittoSwift
 import SwiftUI
 
 class POS_VM: ObservableObject {
-    @Published private(set) var currentOrder: Order?
-    @Published var saleItems: [SaleItem] = SaleItem.demoItems // demo collection for order display
-    private var cancellables = Set<AnyCancellable>()
-    private let dittoService = DittoService.shared
-    
     static var shared = POS_VM()
     
-    private var deviceId: String {
-        dittoService.deviceId
-    }
+    @Published private(set) var currentOrder: Order?
+    @Published var saleItems: [SaleItem] = SaleItem.demoItems // demo collection for order display
+    private let dittoService = DittoService.shared
+    private var cancellables = Set<AnyCancellable>()
+    private var orderCancellable = AnyCancellable({})
 
     private init() {
-        // Try to restore an order from UserDefaults before $currentLocation fires
-        dittoService.restoredIncompleteOrder(for: nil)
-            .sink { [weak self] restoredOrder in
-                self?.currentOrder = restoredOrder
-            }
-            .store(in: &cancellables)
 
-        // Reset an outgoing unpaid currentOrder when locationId changes. This will prevent a
-        // lingering incomplete order in the KDS view of other devices, which would be only
-        // recovered and cleaned up below in $currentLocation.sink via restoredIncompleteOrder
-        // when switching back to that location, or left lingering if not returning.
+        // use case: when DittoService USE_DEFAULT_LOCATIONS is true, the demo locations list
+        // tabView will display, allowing user to change between locations. This is the listener
+        // for that change. We "reset" an unpaid outgoing order to clear it of sale items when
+        // changing locations so that we're not leaving hanging partial orders on other devices'
+        // KDS view.
         NotificationCenter.default.publisher(for: .willUpdateToLocationId)
             .sink {[weak self] locId in
                 guard let self = self else { return }
                 guard let outgoingCurrentOrder = currentOrder,
                       !outgoingCurrentOrder.isPaid,
-                      let _ = dittoService.currentLocation else { return }
+                      let _ = dittoService.currentLocation else {
+                    return
+                }
 
                 dittoService.reset(order: outgoingCurrentOrder)
             }
@@ -49,27 +43,17 @@ class POS_VM: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink {[weak self] loc in
                 guard let loc = loc, let self = self else { return }
-
-                if let order = currentOrder,
-                   order.locationId == loc.id && !order.isPaid {
-                        return
-                    }
                 
-                // Try to restore an incomplete order for the incoming current location and set
-                // it as the currentOrder and return. If there is none, execution will continue
-                // and a new order will be added and set below.
-                dittoService.restoredIncompleteOrder(for: loc.id)
-                    .sink { [weak self] previousOrder in
-                        self?.currentOrder = previousOrder
-                    }
-                    .store(in: &cancellables)
+                if let order = currentOrder, order.locationId == loc.id && !order.isPaid {
+                    return
+                }
 
-                addNewCurrentOrder(for: loc.id)
+                updateCurrentOrder()
             }
             .store(in: &cancellables)
 
-        // Monitor changes in docs for current location, published from DittoService, to update
-        // our published currentOrder, which will cause appropriate UI changes in subscribers.
+        // Monitor changes in locationOrders for current location to update our published
+        // currentOrder, which will cause appropriate UI changes in view subscribers.
         dittoService.$locationOrders
             .receive(on: DispatchQueue.main)
             .sink {[weak self] orders in
@@ -78,17 +62,11 @@ class POS_VM: ObservableObject {
                 // theres nothing to do; return.
                 guard orders.count > 0 else { return }
 
-                // If the DittoService.currentLocationId hasn't been set yet (first launch), we can't
-                // create an order yet, so there's nothing to do here. Actually, I don't think this
-                // should be able to happen. The docs collection is from a location-based query. Well
-                // I suppose it's possible that for a location change DittoService could update the
-                // query (with the new location) which could fire this sink before the currentLocation
-                // publisher is updated... mm... well no, the dittoService.currentLocationId is
-                // updated first, so it should not be possible for locationOrderDocs to be
-                // updated without a currentLocationId - unless there's a race condition, so we
-                // should use the guard to check expectations.
+                // If the DittoService.currentLocationId hasn't been set yet (first launch, where
+                // DittoService USE_DEFAULT_LOCATIONS), we can't create an order yet, so there's
+                // nothing to do here.
                 guard let locId = dittoService.currentLocationId else {
-                    print("POS_VM.dittoService.$locationDocs.sink: ERROR - NIL currentLocationId should not be possible here")
+                    print("POS_VM.dittoService.$locationOrders.sink: ERROR - NIL currentLocationId should not be possible here")
                     return
                 }
                 
@@ -96,14 +74,12 @@ class POS_VM: ObservableObject {
                 // update our published currentOrder, so return.
                 guard let orderId = currentOrder?.id else { return }
 
-                // Create DittoDocumentID with currentOrder.id, filter for this ID, then initialize
-                // and update published currentOrder object.
-                let docID = ["id": orderId, "locationId": locId]
-                if let orderId = orders.first(where: { $0._id == docID }) {
-                    // Last case: should be an order item update - set as currentOrder
-                    currentOrder = orderId
+                // Find an order matching currentOrder. This will be an update, e.g. added saleItem,
+                // or a "reset" for X-Cancel-order button action
+                if let order = orders.first(where: { $0.id == orderId && $0.locationId == locId }) {
+                    currentOrder = order
                 } else {
-                    print("POS_VM.$locationOrderDocs.sink: ERROR - matching doc not found for " +
+                    print("POS_VM.$locationOrders.sink: ERROR - matching doc not found for " +
                           "(docId:\(orderId), locId:\(locId))"
                     )
                 }
@@ -112,7 +88,6 @@ class POS_VM: ObservableObject {
     }
     
     func addOrderItem(_ saleItem: SaleItem) {
-        //TODO: alert user to select location
         guard var curOrder = currentOrder else {
             print("Cannot add item: current order is NIL\n\n");
             return
@@ -136,19 +111,32 @@ class POS_VM: ObservableObject {
         )
 
         dittoService.updateOrderTransaction(order, with: tx)
+        
         // pause a moment to show current order updated to PAID in POSOrderView
         // then create new order automatically
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {[weak self] in
             guard let self = self else { return }
-            // first try to recycle
-            dittoService.restoredIncompleteOrder(for: order.locationId)
-                .sink { [weak self] restoredOrder in
-                    self?.currentOrder = restoredOrder
-                }
-                .store(in: &cancellables)
-
-            addNewCurrentOrder(for: locId)
+            updateCurrentOrder()
         }
+    }
+    
+    func updateCurrentOrder() {
+        guard let locId = dittoService.currentLocationId else {
+            print("POS_VM.\(#function): ERROR: unexpected dittoService.currentLocationId")
+            return
+        }
+        orderCancellable = dittoService.incompleteOrderFuture()
+            .receive(on: DispatchQueue.main)
+            .sink {[weak self] restoredOrder in
+                guard let self = self else { return }
+                if let order = restoredOrder {
+//                    print("POS_VM.\(#function).dittoService.restoredIncompleteOrder(...) FOUND recycled order")
+                    currentOrder = order
+                } else {
+//                    print("POS_VM.\(#function).dittoService.restoredIncompleteOrder(...) ADD NEW order")
+                    addNewCurrentOrder(for: locId)
+                }
+            }
     }
 
     func addNewCurrentOrder(for locId: String) {
@@ -167,7 +155,7 @@ class POS_VM: ObservableObject {
             print("POS_VM.\(#function): ERROR: NIL currentOrder --> RETURN")
             return
         }
-        // Note DS function side-effect sets status to .open
+        // Note DittoService function side-effect sets status to .open
         dittoService.clearSaleItemIds(of: order)
     }
 }


### PR DESCRIPTION
- fix restoredIncompleteOrder: this needed a single-shot return; observer-based publisher cycled infinitely through restorable orders as each was "reset" to clear saleItemIds and set current date. Solved with new incompleteOrderFuture method
- fix KDSOrderView did not update with additional saleItemIds added after initial item: solved removing `.removeDuplicates()` operator
- fix saleItemIds not clearing for X-Cancel-order button action: solved by tombstoning saleItemIds MAP (rather than tombstoning all individual key/vals). Subsequent additions recreates the map and adds values implicitly
- fix add "WHERE id" clause on resetQuery, clearSaleItemIdsQuery  which, when failing were no-ops but would have cleared all saleItemIds in all orders