### PR TITLE
Setup Heartbeat Tool with the Health Metrics from DittoPermissionsHealth

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -335,6 +335,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		14CD51C32A2FE5290018DE87 /* Generate Env.swift */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -342,6 +343,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/buildEnv.sh",
+				"$(SRCROOT)/.env",
 			);
 			name = "Generate Env.swift";
 			outputFileListPaths = (
@@ -526,6 +528,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"DittoPOS/Preview Content\"";
 				DEVELOPMENT_TEAM = 3T2VMFZPPQ;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DittoPOS/Info.plist;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Uses Bluetooth to connect and sync with nearby devices";
@@ -563,6 +566,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"DittoPOS/Preview Content\"";
 				DEVELOPMENT_TEAM = 3T2VMFZPPQ;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DittoPOS/Info.plist;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Uses Bluetooth to connect and sync with nearby devices";
@@ -618,8 +622,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.8.0;
+				branch = BP/health_metrics_fix;
+				kind = branch;
 			};
 		};
 		14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {

--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -622,8 +622,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
 			requirement = {
-				branch = BP/health_metrics_fix;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.8.1;
 			};
 		};
 		14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {

--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		14DECF212A3D16DF005BC2AE /* KDSOrdersGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DECF202A3D16DF005BC2AE /* KDSOrdersGridView.swift */; };
 		14FFFEEF2A43639A00DD6806 /* POSOrderItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FFFEEE2A43639A00DD6806 /* POSOrderItemView.swift */; };
 		14FFFEF12A43732400DD6806 /* SettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FFFEF02A43732400DD6806 /* SettingsModel.swift */; };
+		A4ADA65E2BEAA3E800936AD6 /* DittoHealthMetrics in Frameworks */ = {isa = PBXBuildFile; productRef = A4ADA65D2BEAA3E800936AD6 /* DittoHealthMetrics */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -109,6 +110,7 @@
 				0E1E91A32BA0E40800046BC0 /* DittoHeartbeat in Frameworks */,
 				0E1E91A72BA0E40800046BC0 /* DittoPermissionsHealth in Frameworks */,
 				1435D5AF2A8EC7270046B661 /* DittoSwift in Frameworks */,
+				A4ADA65E2BEAA3E800936AD6 /* DittoHealthMetrics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -274,6 +276,7 @@
 				0E1E91A62BA0E40800046BC0 /* DittoPermissionsHealth */,
 				0E1E91A82BA0E40800046BC0 /* DittoPresenceDegradation */,
 				0E1E91AA2BA0E40800046BC0 /* DittoPresenceViewer */,
+				A4ADA65D2BEAA3E800936AD6 /* DittoHealthMetrics */,
 			);
 			productName = DittoPOS;
 			productReference = 14CD51AD2A2FE2D50018DE87 /* DittoPOS.app */;
@@ -616,7 +619,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.8.0;
 			};
 		};
 		14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {
@@ -684,6 +687,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
 			productName = DittoObjC;
+		};
+		A4ADA65D2BEAA3E800936AD6 /* DittoHealthMetrics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0E1E91992BA0E40800046BC0 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoHealthMetrics;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/getditto/DittoSwiftTools",
       "state" : {
         "branch" : "BP/health_metrics_fix",
-        "revision" : "0d3ee0be9579216bbe862ca8b048590ab9409580"
+        "revision" : "fa46570bc3d5eae22c5c87adff6a0b0faa152c1a"
       }
     },
     {

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "813f35598a8fa9c931a22f18a3f20117f2e42931ac2373c546c2e0f4df7e2d65",
   "pins" : [
     {
       "identity" : "dittoswiftpackage",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "2418e85dd95db011b976336eda47893ba1a29133",
-        "version" : "4.6.0"
+        "revision" : "e9ac25ae9d38d215cc5958c995450dbc9b9dbea7",
+        "version" : "4.7.1"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools",
       "state" : {
-        "revision" : "e78ed387c8467e60c7909b9af2ad5af5eabe076b",
-        "version" : "4.7.4"
+        "revision" : "a8ad598f574de00554572f7feeb1e01e6a87fc20",
+        "version" : "4.8.0"
       }
     },
     {
@@ -28,5 +29,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools",
       "state" : {
-        "branch" : "BP/health_metrics_fix",
-        "revision" : "fa46570bc3d5eae22c5c87adff6a0b0faa152c1a"
+        "revision" : "5e8e1f5614d05686bd9460b6e9e00a9c1f525092",
+        "version" : "4.8.1"
       }
     },
     {

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools",
       "state" : {
-        "revision" : "a8ad598f574de00554572f7feeb1e01e6a87fc20",
-        "version" : "4.8.0"
+        "branch" : "BP/health_metrics_fix",
+        "revision" : "0d3ee0be9579216bbe862ca8b048590ab9409580"
       }
     },
     {

--- a/iOS/DittoPOS/Settings/HeartbeatConfig.swift
+++ b/iOS/DittoPOS/Settings/HeartbeatConfig.swift
@@ -50,7 +50,10 @@ class HeartbeatConfigVM: ObservableObject {
                                             secondsInterval: self.secondsInterval,
                                             metadata: self.metaData,
                                             healthMetricProviders: healthMetricProviders)
-        self.heartbeatVM.startHeartbeat(config: hbConfig) {_ in }
+        self.heartbeatVM.startHeartbeat(config: hbConfig) {heartbeatInfo in
+            print("hb callback")
+            
+        }
     }
     
     func stopHeartbeat() {

--- a/iOS/DittoPOS/Settings/HeartbeatConfig.swift
+++ b/iOS/DittoPOS/Settings/HeartbeatConfig.swift
@@ -8,6 +8,8 @@
 
 import SwiftUI
 import DittoHeartbeat
+import DittoHealthMetrics
+import DittoPermissionsHealth
 
 class HeartbeatConfigVM: ObservableObject {
     
@@ -43,7 +45,12 @@ class HeartbeatConfigVM: ObservableObject {
         if self.heartbeatVM.isEnabled {
             self.stopHeartbeat()
         }
-        self.heartbeatVM.startHeartbeat(config: DittoHeartbeatConfig(id: Settings.deviceId, secondsInterval: self.secondsInterval, metaData: self.metaData)) {_ in }
+        let healthMetricProviders: [HealthMetricProvider] = [DittoPermissionsHealth.BluetoothManager(), DittoPermissionsHealth.NetworkManager()]
+        let hbConfig = DittoHeartbeatConfig(id: Settings.deviceId,
+                                            secondsInterval: self.secondsInterval,
+                                            metadata: self.metaData,
+                                            healthMetricProviders: healthMetricProviders)
+        self.heartbeatVM.startHeartbeat(config: hbConfig) {_ in }
     }
     
     func stopHeartbeat() {

--- a/iOS/DittoPOS/Settings/HeartbeatConfig.swift
+++ b/iOS/DittoPOS/Settings/HeartbeatConfig.swift
@@ -50,10 +50,7 @@ class HeartbeatConfigVM: ObservableObject {
                                             secondsInterval: self.secondsInterval,
                                             metadata: self.metaData,
                                             healthMetricProviders: healthMetricProviders)
-        self.heartbeatVM.startHeartbeat(config: hbConfig) {heartbeatInfo in
-            print("hb callback")
-            
-        }
+        self.heartbeatVM.startHeartbeat(config: hbConfig) {_ in }
     }
     
     func stopHeartbeat() {


### PR DESCRIPTION
Adds the `BluetoothManager` and `NetworkManager` `HealthMetricProvider`s to the Heartbeat Tool implementation.

An example document from `dittotools_devices` based on the output of this tool:

```json
{
  "_id": "6129A38B-24D3-483B-B188-9BEEC6EB9545",
  "_schema": "1",
  "healthMetrics": {
    "DittoPermissionsHealth_Bluetooth": {
      "details": {
        "Authorization Status": "Allowed Always",
        "Current State": "Unsupported"
      },
      "isHealthy": false
    },
    "DittoPermissionsHealth_WiFi": {
      "details": {},
      "isHealthy": true
    }
  },
  "lastUpdated": "2024-05-09T17:08:57Z",
  "metadata": {
    "deviceAttributes": {},
    "deviceName": "",
    "location": {
      "expectedDeviceCount": 0,
      "locationId": "00001",
      "locationName": ""
    },
    "locationAttributes": {}
  },
  "peerKey": "pkAocCgkMDU5JFUfZ5+joTRKw5F1gawUxeXILz4OE5qwI9qoi6A+8=",
  "presenceSnapshotDirectlyConnectedPeers": {},
  "presenceSnapshotDirectlyConnectedPeersCount": 0,
  "sdk": "iOS v4.7.1",
  "secondsInterval": 30
}
```

Depends on https://github.com/getditto/DittoSwiftTools/pull/108

Closes #44