### PR TITLE
Fix Heartbeat tool to keep reporting after leaving heartbeat configuration screen

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "4a89568bb5841b79d85cc807a5aa58780405fed2",
-        "version" : "4.7.4-rc.2"
+        "revision" : "daed815ee575c84065ca5c29b3f4872917da18c4",
+        "version" : "4.7.3"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools",
       "state" : {
-        "branch" : "prerelease/4.7.4-rc.2",
-        "revision" : "50dcc9f9c2cd50161cf7b96e620019f7a67f9946"
+        "revision" : "29b73b7b53d43363e4f90183fc2fccdbfdd6f781",
+        "version" : "4.11.0"
       }
     },
     {

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "daed815ee575c84065ca5c29b3f4872917da18c4",
-        "version" : "4.7.3"
+        "revision" : "4a89568bb5841b79d85cc807a5aa58780405fed2",
+        "version" : "4.7.4-rc.2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools",
       "state" : {
-        "revision" : "29b73b7b53d43363e4f90183fc2fccdbfdd6f781",
-        "version" : "4.11.0"
+        "branch" : "prerelease/4.7.4-rc.2",
+        "revision" : "50dcc9f9c2cd50161cf7b96e620019f7a67f9946"
       }
     },
     {

--- a/iOS/DittoPOS/Settings/HeartbeatConfig.swift
+++ b/iOS/DittoPOS/Settings/HeartbeatConfig.swift
@@ -13,8 +13,6 @@ import DittoPermissionsHealth
 import DittoDiskUsage
 
 class HeartbeatConfigVM: ObservableObject {
-    
-    var heartbeatVM: HeartbeatVM = HeartbeatVM(ditto: DittoService.shared.ditto)
     @Published var isHeartbeatOn: Bool = Settings.isHeartbeatOn
 
     //Heartbeat config
@@ -42,26 +40,6 @@ class HeartbeatConfigVM: ObservableObject {
     @Published var newLocationAttributesKey: String = ""
     @Published var newLocationAttributesValue: String = ""
     
-    func startHeartbeat() {
-        if self.heartbeatVM.isEnabled {
-            self.stopHeartbeat()
-        }
-        let healthMetricProviders: [HealthMetricProvider] = [
-            DittoPermissionsHealth.BluetoothManager(),
-            DittoPermissionsHealth.NetworkManager(),
-            DittoDiskUsage.DiskUsageViewModel(ditto: DittoService.shared.ditto)
-        ]
-        let hbConfig = DittoHeartbeatConfig(id: Settings.deviceId,
-                                            secondsInterval: self.secondsInterval,
-                                            metadata: self.metaData,
-                                            healthMetricProviders: healthMetricProviders)
-        self.heartbeatVM.startHeartbeat(config: hbConfig) {_ in }
-    }
-    
-    func stopHeartbeat() {
-        self.heartbeatVM.stopHeartbeat()
-    }
-    
     func saveConfig() {
         //construct location
         self.location["locationId"] = self.locationId
@@ -77,11 +55,21 @@ class HeartbeatConfigVM: ObservableObject {
         Settings.isHeartbeatOn = self.isHeartbeatOn
         Settings.secondsInterval = self.secondsInterval
         Settings.metaData = self.metaData
-        
+
+        let healthMetricProviders: [HealthMetricProvider] = [
+            DittoPermissionsHealth.BluetoothManager(),
+            DittoPermissionsHealth.NetworkManager(),
+            DittoDiskUsage.DiskUsageViewModel(ditto: DittoService.shared.ditto)
+        ]
+        DittoService.shared.heartbeatConfig = DittoHeartbeatConfig(id: Settings.deviceId,
+                                                                   secondsInterval: self.secondsInterval,
+                                                                   metadata: self.metaData,
+                                                                   healthMetricProviders: healthMetricProviders)
+
         if self.isHeartbeatOn {
-            self.startHeartbeat()
+            DittoService.shared.startHeartbeat()
         } else {
-            self.stopHeartbeat()
+            DittoService.shared.stopHeartbeat()
         }
     }
     


### PR DESCRIPTION
Fixes #48 

Extracts HeartbeatTool configuration & model to DittoService instead of being scoped to the Heartbeat Configuration view, so that it keeps running even when you are not on the configuration screen.