### PR TITLE
Update Ditto SDK to 4.8.1, iOS code cleanup

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		0E1E91AD2BA0FC9300046BC0 /* LogFileConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1E91AC2BA0FC9300046BC0 /* LogFileConfig.swift */; };
 		0E3768B82BAE2FD3009A7053 /* HeartbeatConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3768B72BAE2FD3009A7053 /* HeartbeatConfig.swift */; };
 		112311FF2B3DBA0100A04E44 /* DittoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112311FE2B3DBA0100A04E44 /* DittoExtensions.swift */; };
-		114542CB2C528B3C00DED6A7 /* DittoHealthMetrics in Frameworks */ = {isa = PBXBuildFile; productRef = 114542CA2C528B3C00DED6A7 /* DittoHealthMetrics */; };
 		14039BEE2A465F37001903ED /* POSOrderTotalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14039BED2A465F37001903ED /* POSOrderTotalView.swift */; };
 		14039BF02A4789AE001903ED /* CurrencyUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14039BEF2A4789AE001903ED /* CurrencyUtils.swift */; };
 		140421CF2B9AB6B800778C1B /* AdvancedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140421CE2B9AB6B700778C1B /* AdvancedSettings.swift */; };
@@ -56,7 +55,6 @@
 		14DECF1F2A3D13F0005BC2AE /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DECF1E2A3D13F0005BC2AE /* Utils.swift */; };
 		14DECF212A3D16DF005BC2AE /* KDSOrdersGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DECF202A3D16DF005BC2AE /* KDSOrdersGridView.swift */; };
 		14FFFEEF2A43639A00DD6806 /* POSOrderItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FFFEEE2A43639A00DD6806 /* POSOrderItemView.swift */; };
-		14FFFEF12A43732400DD6806 /* SettingsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FFFEF02A43732400DD6806 /* SettingsModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -712,21 +710,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 07AE54C92C81814400E1FCBD /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
 			productName = DittoPresenceViewer;
-		};
-		114542CA2C528B3C00DED6A7 /* DittoHealthMetrics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0E1E91992BA0E40800046BC0 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoHealthMetrics;
-		};
-		1435D5AE2A8EC7270046B661 /* DittoSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
-			productName = DittoSwift;
-		};
-		14CD51C52A2FE58E0018DE87 /* DittoObjC */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14CD51C42A2FE58E0018DE87 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
-			productName = DittoObjC;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 		};
 		07AE54C92C81814400E1FCBD /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoSwiftTools.git";
+			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 6.0.0;

--- a/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoPOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "dd646f33440358e1a4586b8ae11f884833c9d03f489760c5f92ae42e888a49e0",
+  "originHash" : "813f35598a8fa9c931a22f18a3f20117f2e42931ac2373c546c2e0f4df7e2d65",
   "pins" : [
     {
       "identity" : "dittoswiftpackage",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "fb4ee210d85380084f9bdd26cd5bb987db971da2",
-        "version" : "4.8.0"
+        "revision" : "be46e1e83a65a456bcecc8e9e3e8a76611f70e20",
+        "version" : "4.8.1"
       }
     },
     {

--- a/iOS/DittoPOS/Data/DittoService.swift
+++ b/iOS/DittoPOS/Data/DittoService.swift
@@ -34,22 +34,6 @@ final class DittoInstance {
             token: Env.DITTO_PLAYGROUND_TOKEN,
             enableDittoCloudSync: true
         ), persistenceDirectory: persistenceDirURL)
-
-        // Sync Small Peer Info to Big Peer
-        ditto.smallPeerInfo.isEnabled = true
-        ditto.smallPeerInfo.syncScope = .bigPeerOnly
-
-        try! ditto.disableSyncWithV3()
-
-        Task {
-            // Disabling the BLE setting for performance optimization.
-            // This will be the default behavior starting with v4.8.0, so this can be removed once the SDK is updated.
-            do {
-                try await ditto.store.execute(query: "ALTER SYSTEM SET mesh_chooser_avoid_redundant_bluetooth = false")
-            } catch {
-                assertionFailure(error.localizedDescription)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
- Updates Ditto SDK to 4.8.1 for iOS
- Removes code no longer needed as it became the default behavior in SDK 4.8.0 and newer