### PR TITLE
Refactor logging settings to use DittoLogLevel directly

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -640,7 +640,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
+				minimumVersion = 7.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/iOS/DittoPOS/Data/DittoService.swift
+++ b/iOS/DittoPOS/Data/DittoService.swift
@@ -37,13 +37,16 @@ final class DittoInstance {
     }
 }
 
-let defaultLoggingOption: DittoLogger.LoggingOptions = .error
+let defaultLoggingOption: DittoLogLevel = .error
 
 // Used to constrain orders subscriptions to 1 day old or newer
 let OrderTTL: TimeInterval = 60 * 60 * 24 //24hrs
 
 @MainActor class DittoService: ObservableObject {
-    @Published var loggingOption: DittoLogger.LoggingOptions
+    
+    @State var isLoggingEnabled = DittoLogger.enabled
+    
+    @Published var loggingOption: DittoLogLevel
     private var cancellables = Set<AnyCancellable>()
 
     @Published private(set) var allLocations = [Location]()
@@ -283,14 +286,14 @@ extension DittoService {
 extension DittoService {
     
     private func resetLogging() {
-        let logOption = Settings.dittoLoggingOption
-        switch logOption {
-        case .disabled:
-            DittoLogger.enabled = false
-        default:
-            DittoLogger.enabled = true
-            DittoLogger.minimumLogLevel = DittoLogLevel(rawValue: logOption.rawValue)!
+        // Update DittoLogger's enabled state based on the @State var
+        DittoLogger.enabled = isLoggingEnabled
+        
+        if isLoggingEnabled {
+            // Set the minimum log level based on Settings.dittoLoggingOption
+            DittoLogger.minimumLogLevel = Settings.dittoLoggingOption
             
+            // Configure the log file URL if available
             if let logFileURL = LogFileConfig.createLogFileURL() {
                 DittoLogger.setLogFileURL(logFileURL)
             }

--- a/iOS/DittoPOS/Settings/SettingsView.swift
+++ b/iOS/DittoPOS/Settings/SettingsView.swift
@@ -58,7 +58,7 @@ struct SettingsView: View {
                     }
                 }
                 Section(header: Text("Exports")) {
-                    NavigationLink(destination: LoggingDetailsView(loggingOption: $dittoService.loggingOption)) {
+                    NavigationLink(destination: LoggingDetailsView(ditto: ditto)) {
                         DittoToolsListItem(title: "Logging", systemImage: "square.split.1x2", color: .green)
                     }
 


### PR DESCRIPTION
Creating this PR to review required changes to updating the iOS demo app to work with Tools 7.1.0

- Replaced `LoggingOptions` with `DittoLogLevel` from the Ditto SDK, removing the reference to custom wrapper type.
- Added `isLoggingEnabled` state to separately track logging enablement alongside log levels.
- Updated `SettingsModel`:
  - Refactored `storedLoggingOption` to migrate legacy `UserDefaults` values to `DittoLogLevel` and clean up old keys.
  - Simplified future storage/retrieval to use `DittoLogLevel` directly.
- Modified `SettingsView` constructor to take a `Ditto` instance instead of `LoggingOptions`.

These changes simplify logging logic, align with the updated Ditto SDK, and ensure backward compatibility.