### PR TITLE
[WIP] [Android] Add TTL filter to order queries to prevent displaying stale orders

### DIFF
--- a/Android/app/src/main/java/live/ditto/pos/core/data/orders/ditto/GetOrdersForLocationWithTTLDittoQuery.kt
+++ b/Android/app/src/main/java/live/ditto/pos/core/data/orders/ditto/GetOrdersForLocationWithTTLDittoQuery.kt
@@ -1,0 +1,29 @@
+package live.ditto.pos.core.data.orders.ditto
+
+import kotlinx.datetime.Clock
+import live.ditto.ditto_wrapper.DittoPropertyDeserializer
+import live.ditto.ditto_wrapper.dittowrappers.DittoSelectQuery
+import live.ditto.pos.core.data.orders.Order
+import live.ditto.pos.core.data.orders.toOrder
+import kotlin.time.Duration.Companion.hours
+
+class GetOrdersForLocationWithTTLDittoQuery(
+    locationId: String,
+    ttlHours: Int = 24
+) : DittoSelectQuery<List<Order>> {
+
+    override val queryString: String = GET_ORDERS_FOR_LOCATION_WITH_TTL_QUERY.trimIndent()
+    override val arguments: Map<String, Any> = mapOf(
+        LOCATION_ID_ATTRIBUTE_KEY to locationId,
+        TTL_ATTRIBUTE_KEY to calculateTTL(ttlHours)
+    )
+    override val documentDeserializer: DittoPropertyDeserializer<List<Order>>
+        get() = { dittoProperties ->
+            dittoProperties.map { it.toOrder() }
+        }
+
+    private fun calculateTTL(hours: Int): String {
+        val ttlInstant = Clock.System.now().minus(hours.hours)
+        return ttlInstant.toString()
+    }
+}

--- a/Android/app/src/main/java/live/ditto/pos/core/data/orders/ditto/OrdersDittoCollectionSubscription.kt
+++ b/Android/app/src/main/java/live/ditto/pos/core/data/orders/ditto/OrdersDittoCollectionSubscription.kt
@@ -1,13 +1,24 @@
 package live.ditto.pos.core.data.orders.ditto
 
+import kotlinx.datetime.Clock
 import live.ditto.ditto_wrapper.dittowrappers.DittoCollectionSubscription
+import kotlin.time.Duration.Companion.hours
 
 class OrdersDittoCollectionSubscription(
-    locationId: String
+    locationId: String,
+    ttlHours: Int = 24
 ) : DittoCollectionSubscription {
 
     override val collectionName = ORDERS_COLLECTION_NAME
     override val subscriptionQuery = SUBSCRIPTION_QUERY.trimIndent()
-    override val subscriptionQueryArgs: Map<String, Any> = mapOf(LOCATION_ID_ATTRIBUTE_KEY to locationId)
+    override val subscriptionQueryArgs: Map<String, Any> = mapOf(
+        LOCATION_ID_ATTRIBUTE_KEY to locationId,
+        TTL_ATTRIBUTE_KEY to calculateTTL(ttlHours)
+    )
     override val evictionQuery = "todo" // todo
+
+    private fun calculateTTL(hours: Int): String {
+        val ttlInstant = Clock.System.now().minus(hours.hours)
+        return ttlInstant.toString()
+    }
 }

--- a/Android/app/src/main/java/live/ditto/pos/core/data/orders/ditto/OrdersDittoConstants.kt
+++ b/Android/app/src/main/java/live/ditto/pos/core/data/orders/ditto/OrdersDittoConstants.kt
@@ -10,11 +10,20 @@ const val ORDERS_TRANSACTION_ID_PLACEHOLDER = "{transactionId}"
 const val SUBSCRIPTION_QUERY = """
     SELECT * FROM COLLECTION $ORDERS_COLLECTION_NAME (saleItemIds MAP, transactionIds MAP)
     WHERE _id.locationId = :$LOCATION_ID_ATTRIBUTE_KEY
+        AND createdOn > :$TTL_ATTRIBUTE_KEY
     """
 
 const val GET_ORDERS_FOR_LOCATION_QUERY = """
     SELECT * FROM COLLECTION $ORDERS_COLLECTION_NAME (saleItemIds MAP, transactionIds MAP)
-    WHERE _id.locationId = :$LOCATION_ID_ATTRIBUTE_KEY 
+    WHERE _id.locationId = :$LOCATION_ID_ATTRIBUTE_KEY
+"""
+
+const val TTL_ATTRIBUTE_KEY = "ttl"
+
+const val GET_ORDERS_FOR_LOCATION_WITH_TTL_QUERY = """
+    SELECT * FROM COLLECTION $ORDERS_COLLECTION_NAME (saleItemIds MAP, transactionIds MAP)
+    WHERE _id.locationId = :$LOCATION_ID_ATTRIBUTE_KEY
+        AND createdOn > :$TTL_ATTRIBUTE_KEY
 """
 
 const val INSERT_NEW_ORDER_QUERY = """

--- a/Android/app/src/main/java/live/ditto/pos/core/domain/repository/DittoRepository.kt
+++ b/Android/app/src/main/java/live/ditto/pos/core/domain/repository/DittoRepository.kt
@@ -12,7 +12,7 @@ import live.ditto.pos.core.data.locations.ditto.LocationsDittoCollectionSubscrip
 import live.ditto.pos.core.data.orders.Order
 import live.ditto.pos.core.data.orders.OrderStatus
 import live.ditto.pos.core.data.orders.ditto.AddTransactionToOrderDittoQuery
-import live.ditto.pos.core.data.orders.ditto.GetOrdersForLocationDittoQuery
+import live.ditto.pos.core.data.orders.ditto.GetOrdersForLocationWithTTLDittoQuery
 import live.ditto.pos.core.data.orders.ditto.OrdersDittoCollectionSubscription
 import live.ditto.pos.core.data.transactions.Transaction
 import live.ditto.pos.core.data.transactions.ditto.AddNewTransactionDittoQuery
@@ -60,8 +60,9 @@ class DittoRepository @Inject constructor(
 
     fun ordersForLocation(locationId: String): Flow<List<Order>> {
         return dittoStoreManager.observeLiveQueryAsFlow(
-            GetOrdersForLocationDittoQuery(
-                locationId = locationId
+            GetOrdersForLocationWithTTLDittoQuery(
+                locationId = locationId,
+                ttlHours = 24
             )
         )
     }


### PR DESCRIPTION
  ## Problem
  Android app was displaying all orders regardless of age, including old/stale orders. This was inconsistent with iOS, which filters orders older than 24 hours using a TTL mechanism.

  ## Solution
  Implemented 24-hour TTL filtering for Android order queries to match iOS behavior:
  - Added GET_ORDERS_FOR_LOCATION_WITH_TTL_QUERY with createdOn > :ttl condition
  - Created GetOrdersForLocationWithTTLDittoQuery class to calculate and apply TTL
  - Updated OrdersDittoCollectionSubscription to support TTL filtering
  - Modified DittoRepository.ordersForLocation() to use TTL-filtered queries

  Orders older than 24 hours are now automatically excluded from queries and subscriptions.