### PR TITLE
Update CODEOWNERS: replace legacy dittotools team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 
-* @getditto/product @bplattenburg @kndoshn
+* @getditto/product @getditto/commercial-solutions

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 
-* @getditto/dittotools
+* @getditto/product @bplattenburg @kndoshn


### PR DESCRIPTION
## Summary

- Replace legacy `@getditto/dittotools` team with `@getditto/product` and `@getditto/commercial-solutions` in CODEOWNERS
- The `dittotools` team is a legacy team that no longer reflects current ownership
- Demo app ownership is being transferred to the product and commercial solutions teams