### PR TITLE
Migrate support email to support@ditto.com

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -4,7 +4,7 @@
 
 The app is designed to work on both phones and tablets. There is *some* support for dark mode, but some UI elements may not appear correctly in terms of colors.
 
-For support, please contact Ditto Support (<support@ditto.live>). 
+For support, please contact Ditto Support (<support@ditto.com>). 
 
 ## Project Setup and Run
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ are in process of being prepared, and `processed` - meaning prepared and ready f
 
 The app works on both iOS and Android and can sync between iOS and Android devices as well. 
 
-For support, please contact Ditto Support (<support@ditto.live>).
+For support, please contact Ditto Support (<support@ditto.com>).
 
 ## Running the Apps
 Please see the README in either the `iOS` or `Android` folders for instructions for building and running the code.

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -5,7 +5,7 @@
 This app is designed to work on iPhone and iPad devices in both Portrait and Landscape orientation modes. It may be optimal to use 
 iPhones as order entry devices in the POS tab in Landscape orientation, and iPad for KDS view, also in Landscape mode.
 
-For support, please contact Ditto Support (<support@ditto.live>). 
+For support, please contact Ditto Support (<support@ditto.com>). 
 
 ## Project Setup and Run
 


### PR DESCRIPTION
## Summary
- Updates README support contact across root, iOS/, and Android/ from `support@ditto.live` to `support@ditto.com`.