### PR TITLE
Fix Env.swift generation on clean iOS builds

### DIFF
--- a/iOS/DittoPOS.xcodeproj/project.pbxproj
+++ b/iOS/DittoPOS.xcodeproj/project.pbxproj
@@ -409,7 +409,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Env.swift",
+				"$(SRCROOT)/$(PROJECT)/Env.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
The `Generate Env.swift` build phase writes `iOS/DittoPOS/Env.swift` but declares `$(DERIVED_FILE_DIR)/Env.swift` as its output, so a clean build can start Swift compilation before Xcode recognizes that the missing source file will be generated. Declare the source-tree path the script actually writes. Verified by deleting the ignored `Env.swift`, using fresh DerivedData, and building the `DittoPOS` scheme successfully for an iOS simulator.
