### PR TITLE
Target Android 16 (API 36)

### DIFF
--- a/Android/app/build.gradle.kts
+++ b/Android/app/build.gradle.kts
@@ -14,12 +14,12 @@ plugins {
 
 android {
     namespace = "live.ditto.pos"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "live.ditto.pos"
         minSdk = 28
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 8
         versionName = "2.0.0"
 

--- a/Android/ditto-wrapper/build.gradle.kts
+++ b/Android/ditto-wrapper/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "live.ditto.ditto_wrapper"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28


### PR DESCRIPTION
## Problem
Google Play requires all apps to target Android 16 (API 36) by **Aug 31, 2026**; after that we can't ship app updates. The app currently targets API 35.

## Solution
Bump `compileSdk`/`targetSdk` 35 → 36 (app) and `compileSdk` 34 → 36 (`ditto-wrapper`). Config-only — builds clean on the current toolchain (AGP 8.9.3 / Gradle 8.11.1); no code or AGP changes needed.

Stacked on #90 so it ships with the v5 release.


## ⚠️ Testing needed — not yet verified
This bump compiles and builds clean, but **it has not been run on-device yet.** Targeting API 36 makes **edge-to-edge display mandatory** on Android 16 (the opt-out is gone), so any screen that doesn't handle window insets can render content under the status/navigation bars.

Please test on an **Android 16 (API 36)** device/emulator before merge and check for edge-to-edge / inset regressions:
- POS, KDS, Locations, Settings/Advanced, and the Ditto Tools screens
- status-bar and gesture/navigation-bar areas (content not clipped or hidden)
- landscape + split-screen if applicable

(Author has not tested this yet — calling it out so it isn't assumed working.)
