### PR TITLE
Enable Dependabot for Ditto SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot — automated update PRs for Ditto first-party packages only
+# (SDK + tools). Both platforms are combined into ONE PR per release via a
+# multi-ecosystem group. https://docs.github.com/code-security/dependabot
+# iOS uses the Xcode project's SwiftPM pins and needs a committed Package.resolved.
+version: 2
+multi-ecosystem-groups:
+  ditto:
+    schedule:
+      interval: "weekly"
+updates:
+  # Android — Gradle (com.ditto: SDK + tools)
+  - package-ecosystem: "gradle"
+    directory: "/Android"
+    multi-ecosystem-group: "ditto"
+    patterns:
+      - "com.ditto:*"
+
+  # iOS — Swift Package Manager via the Xcode project
+  - package-ecosystem: "swift"
+    directory: "/iOS"
+    multi-ecosystem-group: "ditto"
+    patterns:
+      - "ditto*"


### PR DESCRIPTION
## Problem
New Ditto releases (SDK and tools) are noticed and bumped by hand — the same manual slog the v5 upgrade required. We want them surfaced automatically.

## Solution
Add `.github/dependabot.yml` with weekly checks scoped to **Ditto (SDK + tools)** on both platforms:
- **Android** (Gradle version catalog): `com.ditto:*` (SDK) + `live.ditto:*` (tools)
- **iOS** (Xcode SwiftPM via Dependabot's `.xcodeproj` support): `dittoswiftpackage` (SDK) + `dittoswifttools` (tools)

Non-Ditto dependencies are not touched.

## Notes
- **Stays stacked** on the v5 chain intentionally — it ships with that release so future SDK/tool bumps stop being manual.
- Dependabot reads config from the **default branch (`main`)**, so it activates once this reaches `main` (i.e., at the v5 release), not before.
- Tools are currently on prereleases (`10.0.0-rc.1` / `6.0.1-rc.1`); once active, Dependabot may open tool-bump PRs too — worth knowing alongside any manual GA re-pin.
- iOS scoping uses SwiftPM package identities (as in `Package.resolved`); glance at the first Dependabot run to confirm they matched.
